### PR TITLE
Phase 1: Ice Bar visibility on external displays + displayID hardening

### DIFF
--- a/Ice/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Ice/MenuBar/IceBar/IceBarColorManager.swift
@@ -29,8 +29,7 @@ final class IceBarColorManager: ObservableObject {
                 .sink { [weak self] screen in
                     guard
                         let self,
-                        let screen,
-                        screen == .main
+                        let screen
                     else {
                         return
                     }
@@ -45,8 +44,7 @@ final class IceBarColorManager: ObservableObject {
                         let self,
                         let iceBarPanel,
                         let screen = iceBarPanel.screen,
-                        isVisible,
-                        screen == .main
+                        isVisible
                     else {
                         return
                     }
@@ -61,8 +59,7 @@ final class IceBarColorManager: ObservableObject {
                         let self,
                         let iceBarPanel,
                         let screen = iceBarPanel.screen,
-                        iceBarPanel.isVisible,
-                        screen == .main
+                        iceBarPanel.isVisible
                     else {
                         return
                     }
@@ -91,8 +88,7 @@ final class IceBarColorManager: ObservableObject {
                 guard
                     let self,
                     let iceBarPanel,
-                    let screen = iceBarPanel.screen,
-                    screen == .main
+                    let screen = iceBarPanel.screen
                 else {
                     return
                 }

--- a/Ice/Utilities/Extensions.swift
+++ b/Ice/Utilities/Extensions.swift
@@ -517,9 +517,10 @@ extension NSScreen {
 
     /// The display identifier of the screen.
     var displayID: CGDirectDisplayID {
-        // Value and type are guaranteed here, so force casting is okay.
-        // swiftlint:disable:next force_cast
-        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! CGDirectDisplayID
+        // The value can be transiently missing during display
+        // reconfiguration; fall back to the main display rather
+        // than crashing.
+        deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? CGDirectDisplayID ?? CGMainDisplayID()
     }
 
     /// A Boolean value that indicates whether the screen has a notch.

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -1,0 +1,52 @@
+# IceMelt Manual Verification Checklist
+
+Run on a macOS 26+ machine before tagging a release. Automated tests don't cover the
+menu bar mechanics (they depend on live OS behavior), so this checklist is the
+regression gate. Check items off in the PR or release notes.
+
+## Setup
+- [ ] Build Release (`xcodebuild -scheme Ice -configuration Release`), launch `IceMelt.app`.
+- [ ] Both `IceMelt` and `MenuBarItemService` processes running (`pgrep -lx IceMelt MenuBarItemService`).
+- [ ] No errors in logs: `/usr/bin/log show --last 5m --predicate 'subsystem == "com.pnikolaidis.icemelt"' | grep -iE "error|fail"`.
+
+## Identification
+- [ ] Settings → Menu Bar Layout shows every third-party item with its real icon.
+- [ ] Hover tooltips show real app names — **no "(UUID)" suffixes**.
+- [ ] Quit and relaunch a third-party menu bar app: its item keeps its section.
+
+## Hide/show mechanics
+- [ ] Click the Ice icon: hidden section collapses/expands.
+- [ ] Option-click: always-hidden section reveals (if enabled).
+- [ ] Show on hover, show on scroll work when enabled.
+- [ ] Auto-rehide (timed and smart) re-hides.
+
+## Layout pane
+- [ ] Items render with pixel-accurate captures (Screen Recording granted).
+- [ ] Drag an item between sections; order persists after the move.
+- [ ] Degraded mode: revoke Screen Recording (`tccutil reset ScreenCapture
+      com.pnikolaidis.icemelt`), relaunch — layout pane shows **app icons**, not
+      "Unable to display menu bar items". Re-grant afterward.
+
+## Ice Bar
+- [ ] Enable Ice Bar; click the Ice icon: pill appears below the menu bar with items.
+- [ ] Items are clickable (left and right click forward correctly).
+- [ ] All three locations work: Dynamic, Mouse pointer, Ice icon — no crash.
+- [ ] On an external display: pill background matches that display's menu bar color.
+
+## Search
+- [ ] Search hotkey opens the panel; fuzzy search finds items; Enter clicks the item.
+
+## Appearance
+- [ ] Tint (solid + gradient), shadow, border render; split shape works.
+- [ ] Settings → General renders correctly; no blank panes.
+
+## Multi-display / spaces (if hardware available)
+- [ ] Hide/show works on a second display's menu bar.
+- [ ] Fullscreen app: Ice idles gracefully, resumes on exit.
+- [ ] Display hot-plug: no crash, layout recovers.
+
+## Known-broken (do not block release)
+- Moving Control Center's own items (Sound, Focus) can fail with "Move events
+  failed" — macOS 26 restricts synthetic drags on CC-internal items.
+- Items owned by apps with no AX presence (some agents publish only as titleless
+  Control Center children) may be unidentifiable — they render but can't be named.


### PR DESCRIPTION
Stacks on #5. Completes the Ice Bar fixes (upstream #665/#786/#679 cluster).

## Changes
- **Color sampling on every display**: `IceBarColorManager` gated all four of its update pipelines on `screen == .main`, so on external displays `colorInfo` stayed nil forever — a contributing factor to 'invisible Ice Bar' reports. The gates are removed; the panel's own screen is sampled.
- **`NSScreen.displayID` crash hardening**: replaced the `NSScreenNumber` force-cast (transiently missing during display reconfiguration) with a `CGMainDisplayID()` fallback.
- The reported crash-on-click (#786) needed no new work — the dev line already guards the `.iceIcon`/`.dynamic` origin path; verified present in this tree.

Together with #5 (item images fall back to app icons), the Ice Bar now renders meaningful content in every degraded configuration we know about.

## Verification
- Build + SwiftLint clean. Manual: enable Ice Bar in settings, confirm pill renders with items on the built-in display; external-display color sampling needs a second monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfgvUUsgteoyg5w2A2Y1Yx