### PR TITLE
Update all docs for the IceMelt fork

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github: jordanbaird
-buy_me_a_coffee: jordanbaird

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Search for Similar Reports
       description: |
-        Please use the search feature on the repository's [Issues](https://github.com/jordanbaird/Ice/issues) page to see if a report already exists for the bug you encountered. Make sure to include both open and closed issues in your search.
+        Please use the search feature on the repository's [Issues](https://github.com/pnikolaidis/icemelt/issues) page to see if a report already exists for the bug you encountered. Make sure to include both open and closed issues in your search.
 
         **Important**: Only submit a new issue if the bug you encountered hasn't been reported in an existing open issue, or if a regression has occurred with a previously closed issue.
       options:
@@ -34,14 +34,14 @@ body:
     id: app_version
     attributes:
       label: App Version
-      placeholder: e.g. 1.2.3
+      placeholder: e.g. 0.12.0-melt.2
     validations:
       required: true
   - type: input
     id: macos_version
     attributes:
       label: macOS Version
-      placeholder: e.g. 15.3.2
+      placeholder: e.g. 26.1
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
     attributes:
       label: Search for Similar Requests
       description: |
-        Please use the search feature on the repository's [Issues](https://github.com/jordanbaird/Ice/issues) page to see if this feature has already been requested. Make sure to include both open and closed issues in your search.
+        Please use the search feature on the repository's [Issues](https://github.com/pnikolaidis/icemelt/issues) page to see if this feature has already been requested. Make sure to include both open and closed issues in your search.
 
         **Important**: Only submit a new issue if the feature you want hasn't been requested in another issue.
       options:

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,10 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-jordanbaird.dev@gmail.com.
+reported to the community leaders responsible for enforcement by opening an
+issue at https://github.com/pnikolaidis/icemelt/issues, or — if the report
+should stay private — through GitHub's private vulnerability/abuse reporting on
+that repository.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/FREQUENT_ISSUES.md
+++ b/FREQUENT_ISSUES.md
@@ -1,35 +1,47 @@
 # Frequent Issues <!-- omit in toc -->
 
 - [Items are moved to the always-hidden section](#items-are-moved-to-the-always-hidden-section)
-- [Ice removed an item](#ice-removed-an-item)
-- [Ice does not remember the order of items](#ice-does-not-remember-the-order-of-items)
-- [How do I solve the `Ice cannot arrange menu bar items in automatically hidden menu bars` error?](#how-do-i-solve-the-ice-cannot-arrange-menu-bar-items-in-automatically-hidden-menu-bars-error)
+- [IceMelt removed an item](#icemelt-removed-an-item)
+- [IceMelt does not remember the order of items](#icemelt-does-not-remember-the-order-of-items)
+- [How do I solve the `IceMelt cannot arrange menu bar items in automatically hidden menu bars` error?](#how-do-i-solve-the-icemelt-cannot-arrange-menu-bar-items-in-automatically-hidden-menu-bars-error)
+- [The Menu Bar Layout pane shows app icons instead of the real items](#the-menu-bar-layout-pane-shows-app-icons-instead-of-the-real-items)
+- [Some Control Center items refuse to move](#some-control-center-items-refuse-to-move)
 
 ## Items are moved to the always-hidden section
 
-By default, macOS adds new items to the far left of the menu bar, which is also the location of Ice's always-hidden section. Most apps are configured
-to remember the positions of their items, but some are not. macOS treats the items of these apps as new items each time they appear. This results in
-these items appearing in the always-hidden section, even if they have been previously been moved.
+By default, macOS adds new items to the far left of the menu bar, which is also the location of IceMelt's always-hidden section. Most apps are
+configured to remember the positions of their items, but some are not. macOS treats the items of these apps as new items each time they appear. This
+results in these items appearing in the always-hidden section, even if they have previously been moved.
 
-Ice does not currently manage individual items, and in fact cannot, as of the current release. Once issues
-[#6](https://github.com/jordanbaird/Ice/issues/6) and [#26](https://github.com/jordanbaird/Ice/issues/26) are implemented, Ice will be able to
-monitor the items in the menu bar, and move the ones it recognizes to their previous locations, even if macOS rearranges them.
+IceMelt does not yet reconcile individual items across relaunches. A canonical menu bar order with background reconciliation — which will file new
+items into the section you chose for them — is planned for Phase 3 in [`PLAN.md`](PLAN.md).
 
-## Ice removed an item
+## IceMelt removed an item
 
-Ice does not have the ability to move or remove items. It likely got placed in the always-hidden section by macOS. Option + click the Ice icon to show
+IceMelt does not have the ability to remove items. It likely got placed in the always-hidden section by macOS. Option + click the IceMelt icon to show
 the always-hidden section, then Command + drag the item into a different section.
 
-## Ice does not remember the order of items
+## IceMelt does not remember the order of items
 
-This is not a bug, but a missing feature. It is being tracked in [#26](https://github.com/jordanbaird/Ice/issues/26).
+This is not a bug, but a missing feature. It is tracked as the canonical-order work in Phase 3 of [`PLAN.md`](PLAN.md).
 
-## How do I solve the `Ice cannot arrange menu bar items in automatically hidden menu bars` error?
+## How do I solve the `IceMelt cannot arrange menu bar items in automatically hidden menu bars` error?
 
 1. Open `System Settings` on your Mac
 2. Go to `Control Center`
 3. Select `Never` as shown in the image below
-4. Update your `Menu Bar Items` in `Ice`
+4. Update your `Menu Bar Items` in `IceMelt`
 5. Return `Automatically hide and show the menu bar` to your preferred settings
 
 ![Disable Menu Bar Hiding](https://github.com/user-attachments/assets/74c1fde6-d310-4fe3-9f2b-703d8ccb636a)
+
+## The Menu Bar Layout pane shows app icons instead of the real items
+
+This is IceMelt's fallback for when it cannot capture the menu bar. Grant Screen Recording permission in `System Settings → Privacy & Security →
+Screen Recording` and relaunch IceMelt to get pixel-accurate item previews. Everything else keeps working without the permission — you just see each
+item's app icon and name rather than its actual appearance.
+
+## Some Control Center items refuse to move
+
+Moving Control Center's own items (Sound, Focus, and similar) can fail with a "Move events failed" error. macOS 26 restricts synthetic drags on
+Control Center's internal items; this is an OS limitation, not something IceMelt can work around today.

--- a/PLAN.md
+++ b/PLAN.md
@@ -24,8 +24,8 @@ distributed outside the Mac App Store (the app cannot be sandboxed).
    that machinery). Optionally: ask scottaw66 for an MIT/GPL grant, which would let us
    port modules directly.
 4. **Fork identity.** Rename app to IceMelt, new bundle ID (`com.pnikolaidis.icemelt`),
-   and **remove or repoint the Sparkle update feed** (`SUFeedURL` currently points at
-   jordanbaird's appcast — shipping with it would auto-"update" our users back to
+   and **remove or repoint the Sparkle update feed** (`SUFeedURL` originally pointed at
+   jordanbaird's appcast — shipping with it would have auto-"updated" our users back to
    upstream Ice). GPL-3.0 retained; keep upstream attribution and license headers.
 5. **Updates: keep Sparkle (fleet decision, 2026-07).** Scratch Itch's closed-source
    apps standardize on a custom appcast self-updater (cmdtab's `UpdateChecker.swift`
@@ -41,9 +41,11 @@ distributed outside the Mac App Store (the app cannot be sandboxed).
       doc/template commits.
 - [x] Rename product to IceMelt; new bundle IDs for app (`com.pnikolaidis.icemelt`) +
       `MenuBarItemService` XPC (service name constant updated in `Shared/Services/`).
-      Target/scheme/folder names still say "Ice" — cosmetic, rename later if desired.
+      Target/scheme/folder names still say "Ice" — tracked as issue #3.
 - [x] Neutralize Sparkle: `SUFeedURL`/`SUPublicEDKey` removed, automatic checks
       disabled until we host our own appcast (GitHub Releases + generated appcast later).
+      *(Superseded 2026-07-18: both keys are now set to IceMelt's own feed and EdDSA
+      public key — see guiding decision 5.)*
 - [x] CI: GitHub Actions `ci.yml` — SwiftLint (container) + Release build on `macos-26`
       runner; replaces upstream's stale `lint.yml`.
 - [x] Deployment target raised to 26.0. Required bridging
@@ -57,27 +59,27 @@ distributed outside the Mac App Store (the app cannot be sandboxed).
 Community demand is unambiguous: the two top-voted issues (74 and 56 👍) are "stable
 version for Tahoe?"; most top bugs are Tahoe symptoms.
 
-- [ ] **Host-app resolution under Control Center ownership** — the branch's central
+- [x] **Host-app resolution under Control Center ownership** — the branch's central
       unsolved problem (commit `ad86802`: "hopefully a temporary measure"). Rework
       `MenuBarItemService/SourcePIDCache` using the MikanBar-proven approach: walk each
       running app's `AXExtrasMenuBar` via Accessibility, resolve AX element → window ID
       via `_AXUIElementGetWindow`, and correlate with the CGS window list, instead of
       trusting window ownership (Control Center owns everything on 26).
       → fixes: items misidentified, "unable to display menu bar items" (#679, #711).
-- [ ] **Fix empty Menu Bar Layout / image cache** (#744, #951, #891, #846 — ~150 👍
+- [x] **Fix empty Menu Bar Layout / image cache** (#744, #951, #891, #846 — ~150 👍
       combined). Two-pronged:
       1. Repair `MenuBarItemImageCache` capture on Tahoe (branch already reverted the
          deprecated-API shim that broke capture for some users).
       2. Add a **no-Screen-Recording fallback**: derive item identity/labels/icons from
          `NSRunningApplication` (MikanBar technique). Layout and search UIs degrade to
          app icons + names instead of a blank pane when capture is unavailable.
-- [ ] **Fix Ice Bar on Tahoe** (#665 invisible, #786 crash).
-- [ ] **Crash on menu bar click** (#947) and the unresponsive Sparkle dialog (#681,
+- [x] **Fix the IceMelt Bar on Tahoe** (#665 invisible, #786 crash).
+- [x] **Crash on menu bar click** (#947) and the unresponsive Sparkle dialog (#681,
       #937) — the latter likely disappears with the Sparkle feed rework.
 - [ ] Triage upstream's macOS 27 beta reports (#965, #954) — build against Xcode 26.x
       SDK, keep 27 breakage on a watchlist; do not block the Tahoe release on it.
 - verify: manual smoke suite on a Tahoe machine (hide/show, layout pane populated,
-  Ice Bar, search, appearance styling) + regression checklist written down in
+  the IceMelt Bar, search, appearance styling) + regression checklist written down in
   `docs/VERIFY.md`.
 - **Milestone: tag v0.12.0-melt.1, publish a notarized release.** This alone leapfrogs
   upstream for most users.
@@ -134,7 +136,7 @@ Ordered by upstream 👍, effort-weighted:
 - [ ] **Conditional visibility triggers** (#62, 68 👍) — show hidden section when
       conditions are met (e.g., app active, battery state). Start minimal: per-app
       triggers.
-- [ ] **Per-display behavior** (#223, 68 👍 / #188 / #303) — Ice Bar or hiding only on
+- [ ] **Per-display behavior** (#223, 68 👍 / #188 / #303) — IceMelt Bar or hiding only on
       the built-in/notched display.
 - [ ] **Settings export/import** (#326, 27 👍) — settings are already Codable-heavy;
       add JSON export. Cheap win, do early if convenient.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,62 @@
 <div align="center">
-    <img src="Ice/Assets.xcassets/AppIcon.appiconset/icon_256x256.png" width=200 height=200>
-    <h1>Ice</h1>
+    <img src="Ice/Resources/Assets.xcassets/AppIcon.appiconset/icon_256x256.png" width=200 height=200>
+    <h1>IceMelt</h1>
 </div>
 
-Ice is a powerful menu bar management tool. While its primary function is hiding and showing menu bar items, it aims to cover a wide variety of additional features to make it one of the most versatile menu bar tools available.
+IceMelt is a menu bar management tool for macOS. Its primary function is hiding and showing menu bar items, alongside a range of additional features that make it one of the most versatile menu bar tools available.
 
-![Banner](https://github.com/user-attachments/assets/4423085c-4e4b-4f3d-ad0f-90a217c03470)
+IceMelt is a fork of [Ice](https://github.com/jordanbaird/Ice) by Jordan Baird, maintained by [Scratch Itch Software](https://scratchitchsoftware.com/icemelt). It exists to deliver a stable, actively maintained build for **macOS 26 (Tahoe) and later** — see [What IceMelt changes](#what-icemelt-changes) below.
 
-[![Download](https://img.shields.io/badge/download-latest-brightgreen?style=flat-square)](https://github.com/jordanbaird/Ice/releases/latest)
+[![Download](https://img.shields.io/badge/download-latest-brightgreen?style=flat-square)](https://github.com/pnikolaidis/icemelt/releases/latest)
 ![Platform](https://img.shields.io/badge/platform-macOS-blue?style=flat-square)
-![Requirements](https://img.shields.io/badge/requirements-macOS%2014%2B-fa4e49?style=flat-square)
-[![Sponsor](https://img.shields.io/badge/Sponsor%20%E2%9D%A4%EF%B8%8F-8A2BE2?style=flat-square)](https://github.com/sponsors/jordanbaird)
-[![Website](https://img.shields.io/badge/Website-015FBA?style=flat-square)](https://icemenubar.app)
-[![License](https://img.shields.io/github/license/jordanbaird/Ice?style=flat-square)](LICENSE)
+![Requirements](https://img.shields.io/badge/requirements-macOS%2026%2B-fa4e49?style=flat-square)
+[![Website](https://img.shields.io/badge/Website-015FBA?style=flat-square)](https://scratchitchsoftware.com/icemelt)
+[![License](https://img.shields.io/github/license/pnikolaidis/icemelt?style=flat-square)](LICENSE)
 
 > [!NOTE]
-> Ice is currently in active development. Some features have not yet been implemented. Download the latest release [here](https://github.com/jordanbaird/Ice/releases/latest) and see the roadmap below for upcoming features.
-
-<a href="https://www.buymeacoffee.com/jordanbaird" target="_blank">
-    <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;">
-</a>
+> IceMelt is in active development. Download the latest release [here](https://github.com/pnikolaidis/icemelt/releases/latest), and see the roadmap below for upcoming work.
 
 ## Install
 
-### Manual Installation
+Download the `IceMelt-<version>.dmg` file from the [latest release](https://github.com/pnikolaidis/icemelt/releases/latest) and drag `IceMelt.app` into your `Applications` folder.
 
-Download the "Ice.zip" file from the [latest release](https://github.com/jordanbaird/Ice/releases/latest) and move the unzipped app into your `Applications` folder.
+Releases are signed with a Developer ID certificate (Paradigm Consulting Company) and notarized by Apple, so they open without a Gatekeeper override.
 
-### Homebrew
+There is no Homebrew cask for IceMelt yet. Note that `brew install --cask jordanbaird-ice` installs **upstream Ice**, not IceMelt.
 
-Install Ice using the following command:
+### Requirements
+
+macOS 26 (Tahoe) or later. See [Why does IceMelt only support macOS 26 and later?](#why-does-icemelt-only-support-macos-26-and-later)
+
+### Updates
+
+IceMelt checks its own signed update feed (`https://pnikolaidis.github.io/icemelt/appcast.xml`) via Sparkle. New versions are offered in-app; automatic checking and downloading are configurable in `Settings → About`.
+
+## Build from source
+
+Requires Xcode 26 or later.
 
 ```sh
-brew install --cask jordanbaird-ice
+git clone https://github.com/pnikolaidis/icemelt.git
+cd icemelt
+xcodebuild -project Ice.xcodeproj -scheme Ice -configuration Release build
 ```
+
+Unsigned local builds are fine for development. Distributable builds are signed with a Developer ID certificate and notarized.
+
+> [!NOTE]
+> The Xcode project, scheme, targets, source folders, and many type names still read `Ice` — leftovers from the fork that have not been renamed yet. Tracked in [#3](https://github.com/pnikolaidis/icemelt/issues/3).
+
+## What IceMelt changes
+
+Relative to upstream Ice (0.11.x and the unreleased `macos-26` branch):
+
+- **Tahoe-correct item identification.** Menu bar items are resolved through Accessibility (an `AXExtrasMenuBar` walk correlated with window IDs) instead of window ownership, which macOS 26 assigns wholesale to Control Center. Items show their real names and icons, and keep their sections across app relaunches.
+- **No hard Screen Recording gate.** When capture is unavailable, the layout and search UIs fall back to app-derived icons and names instead of showing an empty pane.
+- **IceMelt Bar fixes** for visibility and crashes on Tahoe, including correct backgrounds on external displays.
+- **Its own identity and update channel** — bundle ID `com.pnikolaidis.icemelt`, an IceMelt droplet menu bar icon, and a self-hosted Sparkle appcast signed with our own key.
+
+Phase-by-phase plans live in [`PLAN.md`](PLAN.md); the current snapshot is in [`docs/STATUS.md`](docs/STATUS.md).
 
 ## Features/Roadmap
 
@@ -50,6 +73,7 @@ brew install --cask jordanbaird-ice
 - [x] Display hidden menu bar items in a separate bar (e.g. for MacBooks with the notch)
 - [x] Search menu bar items
 - [x] Menu bar item spacing (BETA)
+- [ ] Canonical menu bar order with background reconciliation
 - [ ] Profiles for menu bar layout
 - [ ] Individual spacer items
 - [ ] Menu bar item groups
@@ -64,12 +88,13 @@ brew install --cask jordanbaird-ice
 - [ ] Remove background behind menu bar
 - [ ] Rounded screen corners
 - [ ] Different settings for light/dark mode
+- [ ] Full-black menu bar to hide the notch
 
 ### Hotkeys
 
 - [x] Toggle individual menu bar sections
 - [x] Show the search panel
-- [x] Enable/disable the Ice Bar
+- [x] Enable/disable the IceMelt Bar
 - [x] Show/hide section divider icons
 - [x] Toggle application menus
 - [ ] Enable/disable auto rehide
@@ -79,17 +104,25 @@ brew install --cask jordanbaird-ice
 
 - [x] Launch at login
 - [x] Automatic updates
+- [x] Usable without Screen Recording permission (degraded item previews)
+- [ ] Per-display behavior
+- [ ] Settings export/import
+- [ ] Automated test coverage
 - [ ] Menu bar widgets
 
-## Why does Ice only support macOS 14 and later?
+## Why does IceMelt only support macOS 26 and later?
 
-Ice uses a number of system APIs that are available starting in macOS 14. As such, there are no plans to support earlier versions of macOS.
+IceMelt is built on the Tahoe adaptation of Ice, which reworks menu bar geometry, event handling, and item identification around behavior specific to macOS 26. Supporting macOS 14 and 15 would mean maintaining a large, untested compatibility matrix in exactly the code that is hardest to get right.
+
+If you are on macOS 14 or 15, [upstream Ice 0.11.x](https://github.com/jordanbaird/Ice/releases) works well there.
 
 ## Gallery
 
+> The screenshots below are from upstream Ice. The interface is largely unchanged in IceMelt.
+
 #### Show hidden menu bar items below the menu bar
 
-![Ice Bar](https://github.com/user-attachments/assets/f1429589-6186-4e1b-8aef-592219d49b9b)
+![IceMelt Bar](https://github.com/user-attachments/assets/f1429589-6186-4e1b-8aef-592219d49b9b)
 
 #### Drag-and-drop interface to arrange menu bar items
 
@@ -107,6 +140,16 @@ Ice uses a number of system APIs that are available starting in macOS 14. As suc
 
 ![Menu Bar Item Spacing](https://github.com/user-attachments/assets/b196aa7e-184a-4d4c-b040-502f4aae40a6)
 
+## Contributing
+
+Bug reports and feature requests belong in [IceMelt's issue tracker](https://github.com/pnikolaidis/icemelt/issues) — please don't file IceMelt problems on upstream Ice.
+
+Before reporting a bug, check [FREQUENT_ISSUES.md](FREQUENT_ISSUES.md). Participation is governed by the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Development happens on the `melt` branch; `main` mirrors upstream. CI runs SwiftLint and a Release build on every push and pull request.
+
 ## License
 
-Ice is available under the [GPL-3.0 license](LICENSE).
+IceMelt is available under the [GPL-3.0 license](LICENSE), the same license as upstream Ice.
+
+Copyright © 2026 Scratch Itch Software. Based on [Ice](https://github.com/jordanbaird/Ice), © 2023–2025 Jordan Baird. If IceMelt is useful to you, consider [supporting Jordan Baird](https://github.com/sponsors/jordanbaird), whose work it is built on.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,13 +1,12 @@
 # IceMelt Project Status
 
-Snapshot for resuming work. Everything below is committed and pushed; nothing is
-pending in any working tree.
+Snapshot for resuming work. Last updated 2026-07-29.
 
 ## Where things stand
 
 - **Shipped releases** (GitHub Releases, notarized + stapled DMGs):
   - `v0.12.0-melt.1` — first stable Tahoe release (identification rework, image-cache
-    resilience, Ice Bar fixes)
+    resilience, IceMelt Bar fixes)
   - `v0.12.0-melt.2` — automatic updates (Sparkle feed), IceMelt droplet menu bar icon
     (default), About-pane branding
 - **Automatic updates are live**: feed at `https://pnikolaidis.github.io/icemelt/appcast.xml`
@@ -23,25 +22,42 @@ pending in any working tree.
 - **Plan of record**: `PLAN.md` (phases), `docs/VERIFY.md` (manual regression checklist).
 - Phase 0 (fork hygiene) and Phase 1 (Tahoe correctness) are **complete and verified
   on-device**; the milestone releases shipped.
+- **Naming**: user-facing strings all say "IceMelt". The Xcode project (`Ice.xcodeproj`),
+  targets, scheme, source folders, and most type names (`IceBar`, `IceSection`,
+  `IceWindow`, …) still say "Ice" — issue
+  [#3](https://github.com/pnikolaidis/icemelt/issues/3). Persisted identifiers
+  (`UserDefaults` keys such as `ShowIceIcon`/`UseIceBar`, the `Ice.ControlItem.*` status
+  item autosave names, and `HotkeyAction` raw values) also still say "Ice" and **cannot
+  be renamed without a settings migration** — renaming them silently resets users'
+  configuration.
+- **Untracked in the working tree** (deliberately not committed): `IceMelt app icon
+  design.zip` (designer package), `dist/` (build output), `claude.md` (workflow rules —
+  same file as `CLAUDE.md` on this case-insensitive filesystem).
 
 ## Outstanding — Claude (next session)
 
-1. **Peter's minor bugs** — waiting on issues to be filed (see below); triage and fix.
-2. **Replace the app icon** — `AppIcon.appiconset` still contains upstream Ice's artwork.
-   The design package (`IceMelt app icon design.zip`, repo root, untracked) includes
-   ready `IceMelt-light.iconset`/`IceMelt-dark.iconset`; convert and install.
-3. **Phase 2 (PLAN.md)** — add a test target; extract and unit-test pure logic
+1. **Finish the "Ice" → "IceMelt" rename** (issue #3) — rename the Xcode project,
+   scheme, targets, source folders, and type names; keep persisted keys and autosave
+   names as-is (or add an explicit migration) and comment why. Regression-prone: do it
+   on its own branch with a control build.
+2. **Update the copyright** (issue #4) — verify `INFOPLIST_KEY_NSHumanReadableCopyright`
+   and license headers read "Scratch Itch Software" with upstream attribution.
+3. **Peter's minor bugs** — waiting on issues to be filed (see below); triage and fix.
+4. **Replace the app icon** — `AppIcon.appiconset` still contains upstream Ice's cube
+   artwork. The design package (`IceMelt app icon design.zip`, repo root, untracked)
+   includes ready `IceMelt-light.iconset`/`IceMelt-dark.iconset`; convert and install.
+5. **Phase 2 (PLAN.md)** — add a test target; extract and unit-test pure logic
    (matching/scoring in SourcePIDCache, rehide strategies, hotkey encoding, config
    migration); characterization tests for MenuBarItemManager decision logic; add test
    job to CI.
-4. **Phase 3** — canonical menu bar order + reconciliation, status-item autosave guard,
+6. **Phase 3** — canonical menu bar order + reconciliation, status-item autosave guard,
    crash-safe moves, occlusion detection, first-class Screen-Recording-optional mode.
-5. **Phase 4** — profiles (port stale `upstream/profiles`), conditional visibility
+7. **Phase 4** — profiles (port stale `upstream/profiles`), conditional visibility
    triggers, per-display behavior, settings export, notch-hiding appearance preset,
    URL-scheme/Raycast surface.
-6. **Deferred cleanups**: dead `#available(macOS <26)` branches; two-state droplet icon
+8. **Deferred cleanups**: dead `#available(macOS <26)` branches; two-state droplet icon
    (needs filled/hollow pair from designer); decide whether icon design sources get
-   committed to the repo; macOS 27 beta watch (upstream #965/#954).
+   committed to the repo; macOS 27 beta watch (upstream #965/#954); Homebrew cask.
 
 ## Outstanding — Peter
 
@@ -50,9 +66,11 @@ pending in any working tree.
 2. **Back up the login keychain** (contains the Sparkle EdDSA private key — losing it
    orphans the update channel).
 3. Optional decisions when convenient:
-   - Want the app icon swapped to the droplet artwork? (Task 2 above — say go.)
+   - Want the app icon swapped to the droplet artwork? (Task 4 above — say go.)
    - Ask the designer for a filled/hollow droplet pair for hidden/visible states?
    - Should the icon design sources live in the repo?
+   - Should the rename (task 1) also migrate persisted settings keys, or leave them
+     frozen at their "Ice" spellings for compatibility?
 
 ## How to resume
 

--- a/docs/VERIFY.md
+++ b/docs/VERIFY.md
@@ -15,7 +15,7 @@ regression gate. Check items off in the PR or release notes.
 - [ ] Quit and relaunch a third-party menu bar app: its item keeps its section.
 
 ## Hide/show mechanics
-- [ ] Click the Ice icon: hidden section collapses/expands.
+- [ ] Click the IceMelt icon: hidden section collapses/expands.
 - [ ] Option-click: always-hidden section reveals (if enabled).
 - [ ] Show on hover, show on scroll work when enabled.
 - [ ] Auto-rehide (timed and smart) re-hides.
@@ -27,10 +27,10 @@ regression gate. Check items off in the PR or release notes.
       com.pnikolaidis.icemelt`), relaunch — layout pane shows **app icons**, not
       "Unable to display menu bar items". Re-grant afterward.
 
-## Ice Bar
-- [ ] Enable Ice Bar; click the Ice icon: pill appears below the menu bar with items.
+## IceMelt Bar
+- [ ] Enable the IceMelt Bar; click the IceMelt icon: pill appears below the menu bar with items.
 - [ ] Items are clickable (left and right click forward correctly).
-- [ ] All three locations work: Dynamic, Mouse pointer, Ice icon — no crash.
+- [ ] All three locations work: Dynamic, Mouse pointer, IceMelt icon — no crash.
 - [ ] On an external display: pill background matches that display's menu bar color.
 
 ## Search
@@ -42,7 +42,7 @@ regression gate. Check items off in the PR or release notes.
 
 ## Multi-display / spaces (if hardware available)
 - [ ] Hide/show works on a second display's menu bar.
-- [ ] Fullscreen app: Ice idles gracefully, resumes on exit.
+- [ ] Fullscreen app: IceMelt idles gracefully, resumes on exit.
 - [ ] Display hot-plug: no crash, layout recovers.
 
 ## Known-broken (do not block release)


### PR DESCRIPTION
Every doc in the repo still described upstream Ice. This brings them all current.

## What changed

| File | Fix |
| --- | --- |
| `README.md` | Rewritten: correct repo/release links, DMG install (no Homebrew cask exists — the old command installs *upstream* Ice), macOS 26 requirement, Sparkle update feed, build-from-source, "What IceMelt changes", updated roadmap, contributing, GPL-3.0 + upstream attribution. Also fixes the broken app-icon path — the asset catalog lives in `Ice/Resources/`. |
| `FREQUENT_ISSUES.md` | Rebranded; upstream issue links replaced with `PLAN.md` phase pointers; added two entries this fork actually generates (app-icon fallback without Screen Recording, unmovable Control Center items). |
| `CODE_OF_CONDUCT.md` | Enforcement contact is now this repo's issue tracker / GitHub private reporting, not upstream's maintainer email. |
| `PLAN.md` | Phase 1 checkboxes now match its stated `COMPLETE` status; Phase 0's "neutralize Sparkle" step marked superseded by our own feed. |
| `docs/STATUS.md` | Refreshed; records the naming state and the settings-migration risk behind issue #3. |
| `docs/VERIFY.md` | "Ice Bar" / "Ice icon" → IceMelt. |
| `.github/ISSUE_TEMPLATE/*` | Search links point at this repo; version placeholders use real IceMelt/macOS versions. |
| `.github/FUNDING.yml` | Removed — it routed IceMelt's sponsor button to upstream's author. The README links to him instead. |

Remaining `jordanbaird` references are deliberate upstream attribution.

## Not in this PR

Renaming the Xcode project, targets, scheme, source folders, and type names from `Ice` to `IceMelt` (issue #3). That is a regression-prone code change and needs its own branch — plus a decision on the persisted identifiers (`ShowIceIcon`, `UseIceBar`, `Ice.ControlItem.*` autosave names, `HotkeyAction` raw values), which cannot be renamed without silently resetting users' settings.

Docs-only; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uvBwucV8t7azb6PQTS4AN