### PR TITLE
Use scaledToFit() instead of aspectRatio(contentMode:)

### DIFF
--- a/IceMelt/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/IceMelt/MenuBar/Search/MenuBarSearchPanel.swift
@@ -393,7 +393,7 @@ private struct SettingsButton: View {
         Button(action: action) {
             Image(.iceCubeStroke)
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .foregroundStyle(.secondary)
                 .padding(2)
         }
@@ -420,7 +420,7 @@ private struct ShowItemButton: View {
 
                 Image(systemName: "return")
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(width: 11, height: 11)
                     .foregroundStyle(.secondary)
                     .fontWeight(.bold)
@@ -549,7 +549,7 @@ private struct MenuBarSearchItemView: View {
         if let appIcon {
             Image(nsImage: appIcon)
                 .resizable()
-                .aspectRatio(contentMode: .fit)
+                .scaledToFit()
                 .frame(width: dimension, height: dimension)
         } else {
             RoundedRectangle(cornerRadius: 5)
@@ -558,7 +558,7 @@ private struct MenuBarSearchItemView: View {
                 .overlay {
                     Image(systemName: "rectangle.topthird.inset.filled")
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
+                        .scaledToFit()
                         .foregroundStyle(.white)
                         .padding(3)
                         .shadow(radius: 2)

--- a/IceMelt/Permissions/PermissionsView.swift
+++ b/IceMelt/Permissions/PermissionsView.swift
@@ -52,7 +52,7 @@ struct PermissionsView: View {
             if let nsImage = NSImage(named: NSImage.applicationIconName) {
                 Image(nsImage: nsImage)
                     .resizable()
-                    .aspectRatio(contentMode: .fit)
+                    .scaledToFit()
                     .frame(width: 85, height: 85)
             }
         }

--- a/IceMelt/Settings/SettingsPanes/AboutSettingsPane.swift
+++ b/IceMelt/Settings/SettingsPanes/AboutSettingsPane.swift
@@ -74,7 +74,7 @@ struct AboutSettingsPane: View {
                 if let nsImage = NSImage(named: NSImage.applicationIconName) {
                     Image(nsImage: nsImage)
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
+                        .scaledToFit()
                         .frame(width: 230)
                 }
 

--- a/IceMelt/Utilities/IconResource.swift
+++ b/IceMelt/Utilities/IconResource.swift
@@ -18,7 +18,7 @@ enum IconResource: Hashable {
     var view: some View {
         image
             .resizable()
-            .aspectRatio(contentMode: .fit)
+            .scaledToFit()
     }
 
     /// The image produced by the resource.


### PR DESCRIPTION
Restores CI to green.

CI's SwiftLint runs from `ghcr.io/realm/swiftlint:latest`, which picked up the `legacy_swiftui_aspect_ratio` rule. Under `--strict` that turned 7 pre-existing call sites into errors — taking CI red on the merge of #8, a **docs-only PR that touched zero Swift files**. My local SwiftLint (0.65.0) doesn't have the rule, which is why it passed here.

`scaledToFit()` is defined as `aspectRatio(nil, contentMode: .fit)`, so this is behavior-preserving.

Verified locally: Release build succeeds, `Found 0 violations, 0 serious in 104 files`.

**Worth a separate decision:** the container is pinned to `latest`, so any rule added upstream can turn an unrelated merge red without a line of your code changing. Pinning to a version would make CI reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uvBwucV8t7azb6PQTS4AN