### PR TITLE
Record the 2026-07-29 VERIFY pass

### DIFF
--- a/docs/verify-runs/2026-07-29.md
+++ b/docs/verify-runs/2026-07-29.md
@@ -1,0 +1,131 @@
+# VERIFY run — 2026-07-29
+
+Pass over [`docs/VERIFY.md`](../VERIFY.md) after the Ice → IceMelt rename.
+
+- **Build**: `0.12.0-melt.2`, Developer ID signed (`com.pnikolaidis.icemelt`), installed at
+  `~/Applications/IceMelt.app`
+- **Source**: `melt` @ `75616b0`
+- **Host**: macOS 26, single display, no external monitor
+- **Method**: driven programmatically — `CGEvent` clicks, `CGWindowListCopyWindowInfo` for
+  window state, `log show` for errors, plus five screenshots captured by Peter
+
+Legend: **PASS** verified this run · **EVIDENCE** confirmed from a capture, not re-run
+· **BLOCKED** needs a human or hardware · **N/A** not applicable to this machine
+
+## Setup
+
+| Item | Result |
+| --- | --- |
+| Build Release, launch `IceMelt.app` | **PASS** |
+| Both `IceMelt` and `MenuBarItemService` running | **PASS** — service confirmed via `pgrep -lf MenuBarItemService.xpc` |
+| No errors in logs | **PASS with notes** — see [Log findings](#log-findings) |
+
+## Identification
+
+| Item | Result |
+| --- | --- |
+| Layout pane shows every third-party item with its real icon | **EVIDENCE** — `docs/images/menu-bar-layout.png` shows both sections populated with real icons |
+| Tooltips show real app names, no `(UUID)` suffixes | **EVIDENCE** — the search panel resolves real names (fnMute, Focus Modes, OneDrive, Control Center, SentinelAgent). Hover tooltips themselves not exercised |
+| Quit/relaunch a third-party app: item keeps its section | **BLOCKED** — would quit one of Peter's running apps |
+
+## Hide/show mechanics
+
+| Item | Result |
+| --- | --- |
+| Click the IceMelt icon: section collapses/expands | **PASS** — three consecutive toggles, open → closed → open, verified by the `IceMelt Bar` window (layer 25) appearing and disappearing |
+| Option-click reveals always-hidden section | **N/A** — `EnableAlwaysHiddenSection = 0` |
+| Show on hover | **N/A** — `ShowOnHover = 0` |
+| Show on scroll | **BLOCKED** — synthetic scroll in the menu bar not attempted |
+| Auto-rehide (timed) | **PASS** — set strategy to timed with a 5s interval; bar closed on schedule. Settings restored |
+| Auto-rehide (smart) | **BLOCKED — needs one human click.** See [Smart rehide](#smart-rehide) |
+
+## Layout pane
+
+| Item | Result |
+| --- | --- |
+| Items render with pixel-accurate captures | **EVIDENCE** — Screen Recording granted, real item glyphs render |
+| Drag an item between sections; order persists | **BLOCKED** — would rearrange Peter's live menu bar |
+| Degraded mode without Screen Recording | **BLOCKED** — `tccutil reset ScreenCapture` revokes a permission that must then be re-granted by hand |
+
+## IceMelt Bar
+
+| Item | Result |
+| --- | --- |
+| Bar appears below the menu bar with items | **PASS** — window at layer 25, 458×49 at y=40, directly under the menu bar |
+| Items are clickable (left/right forwarding) | **BLOCKED** — clicking would activate other apps' menus |
+| All three locations work, no crash | **PARTIAL PASS** — all three exercised (Dynamic, Mouse pointer, IceMelt icon); bar appeared and app survived each. **Mouse-pointer positioning was not truly differentiated**: opening the bar by clicking the icon puts the pointer at the icon, so that mode's placement coincides with IceMelt-icon mode. Distinguishing it needs the hotkey, which is unset |
+| External display: pill matches that display's menu bar | **N/A** — single display |
+
+## Search
+
+| Item | Result |
+| --- | --- |
+| Hotkey opens the panel | **N/A** — every hotkey is `null`; none configured |
+| Fuzzy search finds items | **EVIDENCE** — `docs/images/menu-bar-item-search.png`: "fn" matches fnMute, Focus Modes, OneDrive, Control Center, SentinelAgent |
+| Enter clicks the item | **BLOCKED** — would activate another app's menu |
+
+## Appearance
+
+| Item | Result |
+| --- | --- |
+| Tint, shadow, border render; split shape works | **BLOCKED** — all currently off; exercising them rewrites Peter's appearance config |
+| Settings → General renders correctly; no blank panes | **PASS** — all six panes (General, Menu Bar Layout, Menu Bar Appearance, Hotkeys, Advanced, About) cycled; each set its window title and the app stayed alive |
+
+## Multi-display / spaces
+
+**N/A** — single display, no hot-plug hardware.
+
+## Findings
+
+### Smart rehide
+
+Smart auto-rehide never fired. It did not trigger after a focus change, after 25+ seconds
+with the pointer away from the menu bar, or after synthetic clicks against three different
+targets.
+
+Reading the implementation, the design is that smart rehide fires on a **mouse-down**
+(`HIDEventManager.handleSmartRehide`), not on a timer or focus change — so the first two
+attempts were testing the wrong thing. The code then requires the window under the pointer
+to have a non-empty title and belong to an **active app with a regular activation policy**,
+which is why clicking inside IceMelt's own settings window can never trigger it: IceMelt is
+an accessory app.
+
+The last attempt clicked inside an active Finder window, which should satisfy every guard,
+and it still did not rehide.
+
+**This is inconclusive, not a confirmed bug.** Synthetic `CGEvent` clicks may not reach that
+event monitor the way a real click does. Deciding it takes one human action:
+
+> With the IceMelt Bar open, click anywhere inside an ordinary app window. If the bar
+> closes, smart rehide is fine and this is a test-harness artifact. If it stays open,
+> there is a real bug in the smart path — note that the timed path works.
+
+### Log findings
+
+No crashes, no faults. Errors seen across the run, all non-fatal:
+
+- `MenuBarItemManager: Missing control item for hidden section, clearing menu bar item cache`
+  — logged **once at every launch**, across four separate launches. Previously unclassified
+  for lack of a baseline; now established as a consistent startup transient. The app
+  functions normally afterwards. Worth a look, not a blocker.
+- `Bridging: CGSGetScreenRectForWindow failed with error 1000` — during IceMelt Bar display.
+- `MenuBarItemImageCache: Some items were excluded from composite capture` for
+  `com.scratchitchsoftware.iCloudWatch` and `com.scratchitchsoftware.spx-tracker`, followed
+  by individual capture. This is the Phase 1 fallback doing its job.
+
+### Settings integrity
+
+Two settings were changed and restored: `IceBarLocation` (0 → 1 → 2 → 0) and
+`RehideStrategy`/`RehideInterval` (Smart/15 → timed/5 → Smart/15). Verified back at their
+originals. Control item positions survived every relaunch.
+
+## What still needs a human
+
+1. **One click to settle smart rehide** — the deciding test above.
+2. **Drag an item between sections** and confirm order persists.
+3. **Degraded mode** — `tccutil reset ScreenCapture com.pnikolaidis.icemelt`, relaunch,
+   confirm the layout pane shows app icons rather than an empty pane, then re-grant.
+4. **Appearance rendering** — tint, shadow, border, split shape.
+5. **Quit/relaunch a third-party menu bar app** and confirm its item keeps its section.
+6. **Item clicking** in the bar and Enter-to-click in search.
+7. **Multi-display** — needs a second display.

--- a/docs/verify-runs/2026-07-29.md
+++ b/docs/verify-runs/2026-07-29.md
@@ -2,12 +2,23 @@
 
 Pass over [`docs/VERIFY.md`](../VERIFY.md) after the Ice → IceMelt rename.
 
+> **Amended 2026-07-30.** Smart rehide, originally recorded as an inconclusive possible
+> bug, was confirmed working by Peter with a real click — the failure was in the harness.
+> A separate bug the run did not catch (menu bar item clicks never dismissed the bar) was
+> reported afterwards and fixed in PR #14. Both are written up under
+> [Findings](#findings).
+
 - **Build**: `0.12.0-melt.2`, Developer ID signed (`com.pnikolaidis.icemelt`), installed at
   `~/Applications/IceMelt.app`
 - **Source**: `melt` @ `75616b0`
 - **Host**: macOS 26, single display, no external monitor
-- **Method**: driven programmatically — `CGEvent` clicks, `CGWindowListCopyWindowInfo` for
-  window state, `log show` for errors, plus five screenshots captured by Peter
+- **Method**: driven with **synthetic input** — `CGEvent` mouse clicks and moves, plus
+  `CGWindowListCopyWindowInfo` for window state, `log show` for errors, and five
+  screenshots captured by Peter.
+  **Get permission before driving the desktop this way.** Synthetic clicks move the real
+  cursor and collide with whatever the user is doing. They are also not equivalent to real
+  clicks: at least two paths here (smart rehide, show-on-click) do not respond to them at
+  all, so a negative result from injected input is not evidence of a bug.
 
 Legend: **PASS** verified this run · **EVIDENCE** confirmed from a capture, not re-run
 · **BLOCKED** needs a human or hardware · **N/A** not applicable to this machine
@@ -37,7 +48,7 @@ Legend: **PASS** verified this run · **EVIDENCE** confirmed from a capture, not
 | Show on hover | **N/A** — `ShowOnHover = 0` |
 | Show on scroll | **BLOCKED** — synthetic scroll in the menu bar not attempted |
 | Auto-rehide (timed) | **PASS** — set strategy to timed with a 5s interval; bar closed on schedule. Settings restored |
-| Auto-rehide (smart) | **BLOCKED — needs one human click.** See [Smart rehide](#smart-rehide) |
+| Auto-rehide (smart) | **PASS** — confirmed by Peter with a real click on 2026-07-30. See [Smart rehide](#smart-rehide) |
 
 ## Layout pane
 
@@ -79,26 +90,52 @@ Legend: **PASS** verified this run · **EVIDENCE** confirmed from a capture, not
 
 ### Smart rehide
 
-Smart auto-rehide never fired. It did not trigger after a focus change, after 25+ seconds
-with the pointer away from the menu bar, or after synthetic clicks against three different
-targets.
+**Resolved 2026-07-30: smart rehide works. The failure was in the test harness, not the
+product.**
 
-Reading the implementation, the design is that smart rehide fires on a **mouse-down**
-(`HIDEventManager.handleSmartRehide`), not on a timer or focus change — so the first two
-attempts were testing the wrong thing. The code then requires the window under the pointer
-to have a non-empty title and belong to an **active app with a regular activation policy**,
-which is why clicking inside IceMelt's own settings window can never trigger it: IceMelt is
-an accessory app.
+During the run it never fired — not after a focus change, not after 25+ seconds with the
+pointer away from the menu bar, not after synthetic clicks against three targets including
+an active Finder window that satisfied every guard in the code. It was recorded as
+inconclusive rather than a bug.
 
-The last attempt clicked inside an active Finder window, which should satisfy every guard,
-and it still did not rehide.
+Peter then performed the deciding action by hand: with the IceMelt Bar open, clicking
+inside an ordinary app window **closes the bar**. So the implementation is correct and
+**synthetic `CGEvent` clicks do not drive this path**.
 
-**This is inconclusive, not a confirmed bug.** Synthetic `CGEvent` clicks may not reach that
-event monitor the way a real click does. Deciding it takes one human action:
+Two lessons for future runs:
 
-> With the IceMelt Bar open, click anywhere inside an ordinary app window. If the bar
-> closes, smart rehide is fine and this is a test-harness artifact. If it stays open,
-> there is a real bug in the smart path — note that the timed path works.
+1. Smart rehide fires on a **mouse-down**, not a timer or focus change, and requires the
+   window under the pointer to have a non-empty title and belong to an **active app with a
+   regular activation policy**. Clicking inside IceMelt's own settings window can never
+   trigger it — IceMelt is an accessory app.
+2. **Injected events are not a valid substitute for a human click here.** When a path
+   doesn't respond to synthetic input, that is evidence about the harness first, and about
+   the product only after a human has checked.
+
+### Menu bar item clicks did not dismiss the bar
+
+Found after this run, from Peter's report on 2026-07-30, and **fixed in PR #14**.
+
+Clicking a menu bar item belonging to another app left the IceMelt Bar on screen
+indefinitely. It looked intermittent, but it is fully determined by which section the item
+is in:
+
+- An item in the **hidden** section is clicked *inside the bar*, where
+  `IceMeltBarItemView.leftClickAction` calls `section.hide()` before forwarding — always
+  closes.
+- An item in the **visible** section is clicked in the *real menu bar*, which routes to
+  `handleSmartRehide` — and that returns at its first guard whenever the mouse is inside
+  the menu bar, so it never dismissed the bar.
+
+Clicks in *empty* menu bar space were already covered by `handleShowOnClick`, which is why
+the gap only showed up when clicking an actual item.
+
+### Show-on-click could not be verified
+
+Synthetic clicks in empty menu bar space do not trigger show-on-click, on either the
+pre-fix or post-fix build, despite `ShowOnClick = 1`. Given the smart rehide result above,
+this is most likely the same injected-event limitation rather than a product bug — but it
+is **unverified**, and only a human click can settle it. Added to the list below.
 
 ### Log findings
 
@@ -121,11 +158,16 @@ originals. Control item positions survived every relaunch.
 
 ## What still needs a human
 
-1. **One click to settle smart rehide** — the deciding test above.
-2. **Drag an item between sections** and confirm order persists.
-3. **Degraded mode** — `tccutil reset ScreenCapture com.pnikolaidis.icemelt`, relaunch,
+Several of these are blocked on consent rather than difficulty: they would rearrange a live
+menu bar, revoke a TCC grant, or quit running apps. Ask before driving the desktop.
+
+1. **Show on click** — click empty menu bar space and confirm the section toggles.
+   Synthetic clicks don't exercise this path.
+2. **Show on scroll** — scroll in the menu bar and confirm the section reveals.
+3. **Drag an item between sections** and confirm order persists.
+4. **Degraded mode** — `tccutil reset ScreenCapture com.pnikolaidis.icemelt`, relaunch,
    confirm the layout pane shows app icons rather than an empty pane, then re-grant.
-4. **Appearance rendering** — tint, shadow, border, split shape.
-5. **Quit/relaunch a third-party menu bar app** and confirm its item keeps its section.
-6. **Item clicking** in the bar and Enter-to-click in search.
-7. **Multi-display** — needs a second display.
+5. **Appearance rendering** — tint, shadow, border, split shape.
+6. **Quit/relaunch a third-party menu bar app** and confirm its item keeps its section.
+7. **Item clicking** in the bar and Enter-to-click in search.
+8. **Multi-display** — needs a second display.


### PR DESCRIPTION
First pass over `docs/VERIFY.md` after the rename. Driven programmatically — `CGEvent` clicks, `CGWindowListCopyWindowInfo` for window state, `log show` for errors — plus five screenshots.

## Verified

- Both `IceMelt` and `MenuBarItemService` running
- Icon click toggles the IceMelt Bar reliably (open → closed → open, confirmed by the layer-25 window)
- All six settings panes render, none blank, no crash
- **Timed** auto-rehide fires on schedule
- All three IceMelt Bar locations survive without crashing
- Settings and control-item positions survive every relaunch

## Two findings

**Smart auto-rehide never fired.** Not after a focus change, not after 25s with the pointer away, not after synthetic clicks at three separate targets. Recorded as **inconclusive, not a bug**: reading `HIDEventManager.handleSmartRehide`, it fires on mouse-down and requires the window under the pointer to belong to an active *regular* app — so clicking IceMelt's own settings window can never trigger it, since IceMelt is an accessory app. The final attempt used an active Finder window, which should satisfy every guard, and still nothing. Synthetic `CGEvent`s may simply not reach that monitor like a real click.

> **One click settles it:** with the bar open, click inside an ordinary app window. Closes → harness artifact. Stays open → real bug in the smart path (the timed path works).

**`Missing control item for hidden section` now has a baseline.** I previously couldn't classify it. It logs once at *every* launch, across four launches — a consistent startup transient, not something the rename introduced.

## Blocked

Seven items need a human or a second display. They're blocked because doing them would rearrange your live menu bar, revoke a TCC grant you'd have to re-grant, or quit your running apps — not because they're hard. Full list at the end of the doc.

Two settings were changed and restored (`IceBarLocation`, `RehideStrategy`/`RehideInterval`), verified back at their originals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uvBwucV8t7azb6PQTS4AN