### PR TITLE
Dismiss the IceMelt Bar when another menu bar item is clicked

### DIFF
--- a/IceMelt/Events/HIDEventManager.swift
+++ b/IceMelt/Events/HIDEventManager.swift
@@ -52,6 +52,7 @@ final class HIDEventManager: ObservableObject {
         case .leftMouseDown:
             handleShowOnClick(appState: appState, screen: screen)
             handleSmartRehide(with: event, appState: appState, screen: screen)
+            handleIceMeltBarDismissal(with: event, appState: appState, screen: screen)
         case .rightMouseDown:
             handleSecondaryContextMenu(appState: appState, screen: screen)
         default:
@@ -278,6 +279,48 @@ extension HIDEventManager {
             for section in appState.menuBarManager.sections {
                 section.hide()
             }
+        }
+    }
+
+    // MARK: Handle IceMelt Bar Dismissal
+
+    /// Dismisses the IceMelt Bar when a menu bar item belonging to another app is clicked.
+    ///
+    /// Smart rehide can't cover this: it returns as soon as the mouse is inside the menu
+    /// bar, so clicking a visible menu bar item left the bar on screen indefinitely.
+    /// Clicks in empty menu bar space are already handled by ``handleShowOnClick``, and
+    /// clicks on an item inside the bar are handled by the bar's own item actions.
+    private func handleIceMeltBarDismissal(with event: NSEvent, appState: AppState, screen: NSScreen) {
+        // Only act while the bar is actually on screen. This also keeps the handler
+        // inert while the bar's own item actions run, since those close the bar before
+        // forwarding the click to the real menu bar item.
+        guard appState.menuBarManager.iceMeltBarPanel.currentSection != nil else {
+            return
+        }
+
+        // A click inside the bar is the bar's own business.
+        guard event.window !== appState.menuBarManager.iceMeltBarPanel else {
+            return
+        }
+
+        // Clicking one of IceMelt's own control items already toggles the section.
+        for name in MenuBarSection.Name.allCases {
+            guard let controlItem = appState.menuBarManager.controlItem(withName: name) else {
+                continue
+            }
+            if event.window === controlItem.window {
+                return
+            }
+        }
+
+        // Only dismiss for clicks on a menu bar item. Empty menu bar space is
+        // `handleShowOnClick`'s job, and clicks outside the menu bar are smart rehide's.
+        guard isMouseInsideMenuBarItem(appState: appState, screen: screen) else {
+            return
+        }
+
+        for section in appState.menuBarManager.sections {
+            section.hide()
         }
     }
 


### PR DESCRIPTION
Fixes the reported behaviour: clicking **Google Gemini** in the bar closed it, but clicking **CmdTab**, **SPX Tracker**, or **Shottr** left it on screen.

## Why it looked intermittent

It isn't. They're two different code paths, and which one you hit depends on the item's section.

| Item | Section | Path | Result |
| --- | --- | --- | --- |
| Gemini | Hidden | Clicked *inside the bar* → `IceMeltBarItemView.leftClickAction` calls `section.hide()` before forwarding | closes |
| CmdTab, SPX Tracker, Shottr | Visible | Clicked in the *real menu bar* → `handleSmartRehide` | stays open |

`handleSmartRehide` returns at its very first guard whenever the mouse is inside the menu bar (`HIDEventManager.swift:234`):

```swift
!isMouseInsideMenuBar(appState: appState, screen: screen)
```

So no click on any menu bar item ever dismissed the bar. Clicks in *empty* menu bar space were already covered by `handleShowOnClick`, which is why the gap was only visible when clicking an actual item.

## The fix

Adds `handleIceMeltBarDismissal`, deliberately narrow:

- **Inert unless the bar is on screen** (`currentSection != nil`). This also keeps it out of the way during the bar's own item actions, which close the bar *before* forwarding the click — so `temporarilyShow` is unaffected.
- **Ignores clicks inside the bar** — the bar handles those.
- **Ignores clicks on IceMelt's own control items** — those already toggle.
- **Requires the click to land on an item.** Empty menu bar space remains `handleShowOnClick`'s job.

## Verification

A/B against the pre-fix build, same synthetic click at the same coordinates:

| | pre-fix | fixed |
| --- | --- | --- |
| Bar open, click SPX Tracker | **stays open** (reproduces) | **closes** |

Plus regression checks: the icon toggle still alternates correctly over four consecutive clicks, and empty-menu-bar-space clicks behave *identically* on both builds — confirming that path is untouched.

**Unrelated observation, not caused by this change:** synthetic clicks in empty menu bar space don't trigger show-on-click on *either* build. Since `ShowOnClick = 1` and you presumably use it, this is most likely a limitation of injected events rather than a product bug — but it means that one path is only ever confirmed by a human click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uvBwucV8t7azb6PQTS4AN