### PR TITLE
Refresh STATUS.md and point it at the issue tracker

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # IceMelt Project Status
 
-Snapshot for resuming work. Last updated 2026-07-29.
+Snapshot for resuming work. Last updated 2026-07-30.
 
 ## Where things stand
 
@@ -13,9 +13,9 @@ Snapshot for resuming work. Last updated 2026-07-29.
   (served from the `gh-pages` branch). Every future release must append a signed entry
   (see `~/.claude` memory: "IceMelt release recipe"). The EdDSA private key lives in
   Peter's login keychain — **critical secret; include it in keychain backups.**
-- **Branches**: `melt` is the working branch (all work lands here). `main` still mirrors
-  upstream's main + PLAN.md. Upstream remains available as the `upstream` remote for
-  cherry-picking.
+- **Branches**: `melt` is the **default branch** and where all work lands. `main` is now
+  fast-forwarded to match `melt` — it is **no longer an upstream mirror**. Upstream is
+  still available as the `upstream` remote for cherry-picking.
 - **Local install**: the latest signed build always goes to `~/Applications/IceMelt.app`.
 - **CI**: `.github/workflows/ci.yml` — SwiftLint + Release build on the `macos-26`
   runner; green as of the last push.
@@ -25,47 +25,70 @@ Snapshot for resuming work. Last updated 2026-07-29.
 - **Naming (issue #3, done)**: project is `IceMelt.xcodeproj`, scheme/target `IceMelt`,
   source folder `IceMelt/`; all type names and file headers say IceMelt. Build with
   `xcodebuild -project IceMelt.xcodeproj -scheme IceMelt`.
+  **Caveat**: the rename processed `*.swift` only, so `Acknowledgements.rtf`/`.pdf` still
+  say "Ice" in the shipped bundle (issue #15).
   **Deliberately frozen at their "Ice" spellings** because they are persisted on disk and
   renaming them would silently reset users' settings: `UserDefaults` keys
   (`ShowIceIcon`, `IceIcon`, `CustomIceIconIsTemplate`, `UseIceBar`, `IceBarLocation`),
   the `Ice.ControlItem.*` status-item autosave names, `HotkeyAction`'s `"EnableIceBar"`
   raw value, and the "Ice Cube" icon name plus its `IceCube*` assets (upstream's
   artwork, kept as an icon option). Each site carries a comment saying so.
-- **Untracked in the working tree** (deliberately not committed): `IceMelt app icon
-  design.zip` (designer package), `dist/` (build output), `claude.md` (workflow rules —
-  same file as `CLAUDE.md` on this case-insensitive filesystem).
+- **Untracked in the working tree** (deliberately not committed, and now in `.gitignore`):
+  `IceMelt app icon design.zip` (designer package), `dist/` (build output), `claude.md`
+  (workflow rules — same file as `CLAUDE.md` on this case-insensitive filesystem).
+  These were committed by mistake in `d86be07` and untracked again in `c23d852`; the blobs
+  are still in history (issue #19).
+- **App icon**: replaced with the designer's droplet artwork (PR #11). Light variant only;
+  the dark iconset is unused (issue #17).
+- **Unreleased**: `melt` is several merged PRs ahead of the last shipped DMG and
+  `MARKETING_VERSION` is still `0.12.0-melt.2` (issue #18).
 
-## Outstanding — Claude (next session)
+## Outstanding
 
-1. **Update the copyright** (issue #4) — verify `INFOPLIST_KEY_NSHumanReadableCopyright`
-   and license headers read "Scratch Itch Software" with upstream attribution.
-2. **Peter's minor bugs** — waiting on issues to be filed (see below); triage and fix.
-3. **Replace the app icon** — `AppIcon.appiconset` still contains upstream Ice's cube
-   artwork. The design package (`IceMelt app icon design.zip`, repo root, untracked)
-   includes ready `IceMelt-light.iconset`/`IceMelt-dark.iconset`; convert and install.
-4. **Phase 2 (PLAN.md)** — add a test target; extract and unit-test pure logic
-   (matching/scoring in SourcePIDCache, rehide strategies, hotkey encoding, config
-   migration); characterization tests for MenuBarItemManager decision logic; add test
-   job to CI.
-5. **Phase 3** — canonical menu bar order + reconciliation, status-item autosave guard,
-   crash-safe moves, occlusion detection, first-class Screen-Recording-optional mode.
-6. **Phase 4** — profiles (port stale `upstream/profiles`), conditional visibility
-   triggers, per-display behavior, settings export, notch-hiding appearance preset,
-   URL-scheme/Raycast surface.
-7. **Deferred cleanups**: dead `#available(macOS <26)` branches; two-state droplet icon
-   (needs filled/hollow pair from designer); decide whether icon design sources get
-   committed to the repo; macOS 27 beta watch (upstream #965/#954); Homebrew cask.
+Everything discrete is now a GitHub issue — see
+https://github.com/pnikolaidis/icemelt/issues. This list is the map, not the detail.
+
+### Open issues
+
+| # | Item |
+| --- | --- |
+| [#4](https://github.com/pnikolaidis/icemelt/issues/4) | Update copyright — Info.plist is already correct; the acknowledgements text is the remaining piece |
+| [#15](https://github.com/pnikolaidis/icemelt/issues/15) | `Acknowledgements.rtf`/`.pdf` still say "Ice" in the shipped bundle |
+| [#16](https://github.com/pnikolaidis/icemelt/issues/16) | Pin the SwiftLint CI container instead of `:latest` — already reddened CI once on a docs-only merge |
+| [#17](https://github.com/pnikolaidis/icemelt/issues/17) | Wire up the dark app-icon variant |
+| [#18](https://github.com/pnikolaidis/icemelt/issues/18) | Ship a release — rename, icon, and the bar-dismissal fix are all unreleased |
+| [#19](https://github.com/pnikolaidis/icemelt/issues/19) | Purge the design package and DMG from git history (only needed if the repo goes public) |
+
+### Verification debt
+
+`docs/verify-runs/2026-07-29.md` records the last pass. Several items still need a real
+human click and **cannot be done with synthetic input** — show on click, show on scroll,
+layout drag, degraded mode (no Screen Recording), appearance rendering, multi-display.
+Issue #18 is blocked on these.
+
+### Roadmap (PLAN.md)
+
+- **Phase 2** — test target; unit-test pure logic (SourcePIDCache matching, rehide
+  strategies, hotkey encoding, config migration); characterization tests for
+  MenuBarItemManager; add a test job to CI.
+- **Phase 3** — canonical menu bar order + reconciliation, status-item autosave guard,
+  crash-safe moves, occlusion detection, first-class Screen-Recording-optional mode.
+- **Phase 4** — profiles (port stale `upstream/profiles`), conditional visibility
+  triggers, per-display behavior, settings export, notch-hiding appearance preset,
+  URL-scheme/Raycast surface.
+- **Deferred cleanups**: dead `#available(macOS <26)` branches; two-state droplet menu bar
+  icon (needs a filled/hollow pair from the designer); macOS 27 beta watch (upstream
+  #965/#954); Homebrew cask; one hotlinked upstream image left in `FREQUENT_ISSUES.md`.
 
 ## Outstanding — Peter
 
-1. **File the minor bugs** you mentioned as GitHub issues
-   (https://github.com/pnikolaidis/icemelt/issues) so they can be worked.
-2. **Back up the login keychain** (contains the Sparkle EdDSA private key — losing it
-   orphans the update channel).
-3. Optional decisions when convenient:
-   - Want the app icon swapped to the droplet artwork? (Task 3 above — say go.)
-   - Ask the designer for a filled/hollow droplet pair for hidden/visible states?
+1. **File the minor bugs** you mentioned as GitHub issues so they can be worked.
+2. **Back up the login keychain** — it holds the Sparkle EdDSA private key; losing it
+   orphans the update channel.
+3. Decisions when convenient:
+   - Ask the designer for a filled/hollow droplet pair for hidden/visible menu bar states?
    - Should the icon design sources live in the repo?
+   - Purge git history (#19), or leave it since the repo is private?
 
 ## How to resume
 


### PR DESCRIPTION
Answers "are all open issues documented in the repo?" — they weren't. Six were living only in chat.

## Stale claims fixed

- Listed the **app icon swap as outstanding** — done in PR #11
- Described **`main` as an upstream mirror** — it's now fast-forwarded to `melt`, which is the default branch
- Asked you to decide on the droplet swap you'd already approved

## Newly documented (were tracked nowhere)

| Issue | Item |
| --- | --- |
| #15 | `Acknowledgements.rtf`/`.pdf` still say "Ice" in the shipped bundle |
| #16 | SwiftLint CI container pinned to `:latest` |
| #17 | Dark app-icon variant unused |
| #18 | Rename, icon, and bar-dismissal fix all unreleased |
| #19 | Design package + DMG blobs still in history at `d86be07` |

**#15 is a miss of mine.** The rename processed `*.swift` only, so `Acknowledgements.rtf` — which ships in the bundle and is reachable from the About pane — still opens with *"Ice uses a number of excellent open source libraries."* My claim in PR #9 that no user-visible "Ice" remained was wrong. It also means issue #4 has more left in it than the Info.plist line, which is already correct.

## Structure

The Outstanding section now points at the tracker rather than duplicating it — carrying the list inline is exactly how those six items went unrecorded. Verification debt gets its own section noting which items **cannot** be done with synthetic input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uvBwucV8t7azb6PQTS4AN