### PR TITLE
Pin the SwiftLint CI container to 0.65.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: ghcr.io/realm/swiftlint:latest
+    # Pinned (issue #16): a floating :latest once turned CI red on a docs-only
+    # merge when a new rule landed upstream. Bump deliberately, matching the
+    # version developers run locally.
+    container: ghcr.io/realm/swiftlint:0.65.0
     steps:
       - uses: actions/checkout@v4
       - name: Run SwiftLint


### PR DESCRIPTION
Closes #16.

`:latest` already turned CI red once on a docs-only merge (#8) when the container picked up `legacy_swiftui_aspect_ratio`. Pin to 0.65.0 — the version developers run locally and what `:latest` resolves to today, so this is behavior-neutral now and reproducible later. Bump deliberately from here on.

The lint job on this very PR exercises the pinned container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uvBwucV8t7azb6PQTS4AN