### PR TITLE
Dispatch cursor hide/show to the main thread to stop hide-count leaks

### DIFF
--- a/IceMelt/Utilities/MouseHelpers.swift
+++ b/IceMelt/Utilities/MouseHelpers.swift
@@ -4,6 +4,7 @@
 //
 
 import CoreGraphics
+import Foundation
 import OSLog
 
 /// A namespace for mouse helper operations.
@@ -23,19 +24,35 @@ enum MouseHelpers {
     }
 
     /// Hides the mouse cursor and increments the hide cursor count.
+    ///
+    /// The hide cursor count is tracked per window server connection,
+    /// and connections are created per thread. Both this function and
+    /// ``showCursor()`` dispatch to the main thread so that every
+    /// hide/show pair lands on the same connection — a pair split
+    /// across cooperative pool threads leaks a hide count that takes
+    /// effect the next time the app is activated. The main thread's
+    /// connection is also the one that carries the
+    /// `SetsCursorInBackground` property set at launch.
     static func hideCursor() {
-        let result = CGDisplayHideCursor(CGMainDisplayID())
-        if result != .success {
-            Logger.default.error("CGDisplayHideCursor failed with error \(result.logString, privacy: .public)")
+        DispatchQueue.main.async {
+            let result = CGDisplayHideCursor(CGMainDisplayID())
+            if result != .success {
+                Logger.default.error("CGDisplayHideCursor failed with error \(result.logString, privacy: .public)")
+            }
         }
     }
 
     /// Decrements the hide cursor count and shows the mouse cursor
     /// if the count is `0`.
+    ///
+    /// Dispatched to the main thread for the reasons described in
+    /// ``hideCursor()``.
     static func showCursor() {
-        let result = CGDisplayShowCursor(CGMainDisplayID())
-        if result != .success {
-            Logger.default.error("CGDisplayShowCursor failed with error \(result.logString, privacy: .public)")
+        DispatchQueue.main.async {
+            let result = CGDisplayShowCursor(CGMainDisplayID())
+            if result != .success {
+                Logger.default.error("CGDisplayShowCursor failed with error \(result.logString, privacy: .public)")
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #28.

## Root cause

`CGDisplayHideCursor`/`CGDisplayShowCursor` maintain the hide cursor count **per window server connection**, and connections are per **thread**. Three of the seven hide/show pairs in `MenuBarItemManager` are in `nonisolated` async functions (`postEventWithBarrier`, `scrombleEvent`, `waitForMoveEventResponse`): the hide runs on whichever cooperative-pool thread enters the function, and the matching `showCursor()` sits in a `defer` that executes after suspension points — often on a *different* pool thread. The hide count on the first thread's connection is never decremented; the show on the second thread's connection is a no-op.

`SetsCursorInBackground` is only set on the main connection (`AppDelegate.swift:31`), so the leaked counts have no visible effect while IceMelt is a background app. They apply the moment the app activates — which is what `openSettingsWindow()` does, hence "the cursor vanishes when the settings UI launches."

**Confirmed against the diagnosis in #28:** with the cursor invisible, Cmd-Tabbing to another app brings it back, and refocusing IceMelt makes it vanish again — exactly the predicted signature of a leaked count scoped to IceMelt's own connections.

## Fix

Both `MouseHelpers.hideCursor()` and `showCursor()` now dispatch their CG call to the main queue:

- Every hide/show pair lands on the **same** connection (main thread's), so counts always balance.
- Nesting stays correct: the main queue is FIFO and each operation's hide/show calls are sequenced by its `await` chain, so the count never transiently hits 0 mid-operation.
- Every hide now runs on the one connection that actually carries `SetsCursorInBackground`, so hiding during background moves keeps working as designed.

Chose this over the `withCursorHidden { }` closure helper floated in #28: two-function change, zero churn at the seven call sites, and no closure-isolation complications. The only behavioral difference is that the hide becomes asynchronous (next main-queue drain), which is well inside the several-ms setup the event-posting machinery does before any synthetic event moves the real cursor.

Considered and deferred: a drain-the-count backstop on `didBecomeActive`. There is no API to read the count, so a backstop means blind bounded `CGDisplayShowCursor` loops gated on "no operation in flight" — complexity that shouldn't be needed once pairs can't split across connections. Can revisit if the symptom ever reappears.

## Verification

- Release build passes; notarized (`b574b843-61a2-4765-a6ec-c11624059915`, Accepted) and stapled; `spctl` assesses as Notarized Developer ID.
- Staged to `~/Applications/IceMelt.app`. Manual test after relaunch: exercise item moves (show/hide sections, IceMelt Bar clicks), then open Settings repeatedly — cursor should stay visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqfjkDXQ76HtH1pyHUHLkA
